### PR TITLE
Explicitly set the log level to warning.

### DIFF
--- a/rocket/main.py
+++ b/rocket/main.py
@@ -24,6 +24,7 @@ from .listener import Listener
 
 # Setup Logging
 log = logging.getLogger('Rocket')
+log.setLevel(logging.WARNING)
 log.addHandler(NullHandler())
 
 class Rocket(object):


### PR DESCRIPTION
I use Rocket for a couple of lightweight Python web applications, and really like its simplicity (and name!) when combined with bottle. However, one frustrating item is that if I set my application's basic log level to debug, it propagates down into Rocket and I get tons of unnecessary log messages.

I suggest the included change, which explicitly sets the Rocket log level. If a user wants to override this setting later, it's quite easy to do external to Rocket:

```
logging.getLogger('Rocket').setLevel(logging.DEBUG)
```
